### PR TITLE
Update 'main' references in bower configuration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,10 @@
     "angular",
     "modules"
   ],
-  "main": "index.js",
+  "main": [
+    "dist/ng-backstretch.min.js",
+    "dist/ng-backstretch.min.js.map"
+  ],
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Point "main" section to the dist folder instead of index.js.  This enables the component to work properly with the grunt-wiredep task runner.