### PR TITLE
Update ng-backstretch.js

### DIFF
--- a/src/ng-backstretch.js
+++ b/src/ng-backstretch.js
@@ -11,9 +11,9 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
   return {
     restrict: 'A',
     scope: {
-      images: '&backstretchImages',
-      duration: '&backstretchDuration',
-      fade: '&backstretchFade'
+      images: '=backstretchImages',
+      duration: '=?backstretchDuration',
+      fade: '=?backstretchFade'
     },
     link: function(scope, element, attributes) {
 
@@ -21,9 +21,9 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
        * e.g. <div backstretch backstretch-url="'/path/to/image.jpg'">
        * So, we need to turn this back into an array.
        */
-      scope.images = Array.isArray(scope.images()) ? scope.images() : [scope.images()];
-      scope.duration = scope.duration() || 5000;
-      scope.fade = scope.fade() || 1;
+      scope.images = Array.isArray(scope.images) ? scope.images : [scope.images];
+      scope.duration = !angular.isUndefined(scope.duration) ? scope.duration : 5000;
+      scope.fade = !angular.isUndefined(scope.fade) ? scope.fade : 1;
 
       // We need at least one image or method name
       if (scope.images.length === 0) {


### PR DESCRIPTION
Update directive to use two way bindings instead of expressions; make duration and fade optional; previously scope.duration would get initialized to 5000 no matter what was passed in for duration and scope.fade would get initialized to 1 no matter what was passed in for fade.  Directive now respects properties passed in but defaults duration and fade to 5000 and 1 respectively if values are not provided.