### PR TITLE
Switching images by "active" class

### DIFF
--- a/demo/ng-backstretch.html
+++ b/demo/ng-backstretch.html
@@ -1,9 +1,6 @@
 <html ng-app="ng-backstretch-demo">
 <head>
   <title>ng-backstretch demo</title>
-
-  <link rel="stylesheet" type="text/css" href="../src/ng-backstretch.css">
-
   <style type="text/css">
     body {
       margin: 0;
@@ -13,7 +10,6 @@
       width: 100%;
       height: 100%;
     }
-
   </style>
 
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.28/angular.js"></script>

--- a/demo/ng-backstretch.html
+++ b/demo/ng-backstretch.html
@@ -2,6 +2,8 @@
 <head>
   <title>ng-backstretch demo</title>
 
+  <link rel="stylesheet" type="text/css" href="../src/ng-backstretch.css">
+
   <style type="text/css">
     body {
       margin: 0;
@@ -11,6 +13,7 @@
       width: 100%;
       height: 100%;
     }
+
   </style>
 
   <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.28/angular.js"></script>

--- a/src/ng-backstretch.css
+++ b/src/ng-backstretch.css
@@ -1,0 +1,8 @@
+.backstretch img {
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+.backstretch img.active {
+  opacity: 1;
+}

--- a/src/ng-backstretch.js
+++ b/src/ng-backstretch.js
@@ -169,7 +169,7 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
             // remove "active" class when duration has been reached
             scope.image.removeClass('active');
           } else {
-            // show the image since it's finished loading
+            // hide it once the duration has been reached
             scope.image.css({opacity:0});
           }
           

--- a/src/ng-backstretch.js
+++ b/src/ng-backstretch.js
@@ -12,7 +12,9 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
     restrict: 'A',
     scope: {
       images: '&backstretchImages',
-      duration: '&backstretchDuration'
+      duration: '&backstretchDuration',
+      fade: '&backstretchFade',
+      css_transition: '@backstretchCssTransition'
     },
     link: function(scope, element, attributes) {
 
@@ -22,6 +24,7 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
        */
       scope.images = Array.isArray(scope.images()) ? scope.images() : [scope.images()];
       scope.duration = scope.duration() || 5000;
+      scope.fade = scope.fade() || 0;
 
       // We need at least one image or method name
       if (scope.images.length === 0) {
@@ -58,6 +61,12 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
           zIndex: -999999
         }
       };
+
+      // if we do not use css transition
+      if(scope.css_transition !== 'true') {
+        styles.image.opacity = 0;
+        styles.image.transition = 'all '+scope.fade+'s';
+      }
 
       // create the scope.wrapper element
       scope.wrapper = angular.element('<div class="backstretch"></div>');
@@ -145,12 +154,25 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
           scope.index = 0;
         }
 
-        // Apply "active" since it's finished loading
-        scope.image.addClass('active');
+        if(scope.css_transition === 'true') {
+          // apply "active" class since it's finished loading
+          scope.image.addClass('active');
+        } else {
+          // show the image since it's finished loading
+          scope.image.css({opacity:1});
+        }
+        
 
-        // Remove "active" class when duration has been reached
+        
         $timeout(function(){
-          scope.image.removeClass('active');
+          if(scope.css_transition === 'true') {
+            // remove "active" class when duration has been reached
+            scope.image.removeClass('active');
+          } else {
+            // show the image since it's finished loading
+            scope.image.css({opacity:0});
+          }
+          
         }, scope.duration);
 
         $timeout(function(){

--- a/src/ng-backstretch.js
+++ b/src/ng-backstretch.js
@@ -145,7 +145,11 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
 
         // only one image
         if (scope.images.length === 1) {
-          scope.image.addClass('active');
+          if(scope.css_transition === 'true') {
+            scope.image.addClass('active');
+          } else {
+            scope.image.css({opacity:1});  
+          }
           return;
         }
 

--- a/src/ng-backstretch.js
+++ b/src/ng-backstretch.js
@@ -12,8 +12,7 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
     restrict: 'A',
     scope: {
       images: '&backstretchImages',
-      duration: '&backstretchDuration',
-      fade: '&backstretchFade'
+      duration: '&backstretchDuration'
     },
     link: function(scope, element, attributes) {
 
@@ -23,7 +22,6 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
        */
       scope.images = Array.isArray(scope.images()) ? scope.images() : [scope.images()];
       scope.duration = scope.duration() || 5000;
-      scope.fade = scope.fade() || 0;
 
       // We need at least one image or method name
       if (scope.images.length === 0) {
@@ -50,7 +48,6 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
         },
         image: {
           position: 'absolute',
-          opacity: 0,
           margin: 0,
           padding: 0,
           border: 'none',
@@ -58,8 +55,7 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
           height: 'auto',
           maxHeight: 'none',
           maxWidth: 'none',
-          zIndex: -999999,
-          transition: 'all '+scope.fade+'s'
+          zIndex: -999999
         }
       };
 
@@ -140,7 +136,7 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
 
         // only one image
         if (scope.images.length === 1) {
-          scope.image.css({opacity:1});
+          scope.image.addClass('active');
           return;
         }
 
@@ -149,12 +145,12 @@ directive('backstretch', ['$window', '$timeout', function($window, $timeout) {
           scope.index = 0;
         }
 
-        // show the image since it's finished loading
-        scope.image.css({opacity:1});
+        // Apply "active" since it's finished loading
+        scope.image.addClass('active');
 
-        // hide it once the duration has been reached
+        // Remove "active" class when duration has been reached
         $timeout(function(){
-          scope.image.css({opacity:0});
+          scope.image.removeClass('active');
         }, scope.duration);
 
         $timeout(function(){

--- a/src/ng-backstretch.scss
+++ b/src/ng-backstretch.scss
@@ -1,0 +1,9 @@
+.backstretch {
+  img {
+    opacity: 0;
+    transition: opacity 1s ease;
+    &.active {
+      opacity: 1;
+    }
+  }
+}

--- a/src/ng-backstretch.scss
+++ b/src/ng-backstretch.scss
@@ -1,9 +1,0 @@
-.backstretch {
-  img {
-    opacity: 0;
-    transition: opacity 1s ease;
-    &.active {
-      opacity: 1;
-    }
-  }
-}


### PR DESCRIPTION
Hardcoded inline transition is very hard to rewrite, hence it looks very weird in Safari. By pulling out the transition settings back to stylesheet, we can do much more in there.
